### PR TITLE
Do not call back into later for promise completion

### DIFF
--- a/R/promise.R
+++ b/R/promise.R
@@ -68,12 +68,10 @@ Promise <- R6::R6Class(
       private$visible <- visible
       private$state <- "fulfilled"
 
-      later::later(function() {
-        lapply(private$onFulfilled, function(f) {
-          f(private$value, private$visible)
-        })
-        private$onFulfilled <- list()
+      lapply(private$onFulfilled, function(f) {
+        f(private$value, private$visible)
       })
+      private$onFulfilled <- list()
     },
     doRejectFinalReason = function(reason) {
       private$value <- reason


### PR DESCRIPTION
Tested under:

```r
library(promises)

then(mirai::mirai(1), function(x) stop("outer"))
then(mirai::mirai(stop("inner")), function(x) stop("outer"))
then(mirai::mirai(non), function(x) stop("outer"))
then(mirai::mirai(stop("inner")), function(x) stop("outer"), function(x) stop("rejected"))
then(mirai::mirai(rexp()), function(x) stop("outer"), function(x) print(x))
then(mirai::mirai(TRUE), print)
mirai::mirai(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) stop("rejected"))
mirai::mirai(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) print(x))
mirai::mirai(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) stop("really rejected"))
mirai::mirai(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) print(paste0("not really ", x)))

then(future_promise(1), function(x) stop("outer"))
then(future_promise(stop("inner")), function(x) stop("outer"))
then(future_promise(non), function(x) stop("outer"))
then(future_promise(stop("inner")), function(x) stop("outer"), function(x) stop("rejected"))
then(future_promise(rexp()), function(x) stop("outer"), function(x) print(x))
then(future_promise(TRUE), print)
future_promise(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) stop("rejected"))
future_promise(1) |> then(\(x) stop("outer1")) |> then(\(x) stop("resolved"), \(x) print(x))
future_promise(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) stop("really rejected"))
future_promise(stop("inner")) |> then(\(x) stop("resolved"), \(x) "rejected") |> then(\(x) print(paste0("not really ", x)))

```